### PR TITLE
Remove jQuery

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -24,10 +24,6 @@
         crossorigin="anonymous"></script>
     <!-- Custom CSS -->
     <link href="/static/styles/style.css" rel="stylesheet" />
-
-    <!-- jQuery usable in the page body -->
-    <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
-
     {% endblock %}
 </head>
 

--- a/web/templates/faq.html
+++ b/web/templates/faq.html
@@ -326,15 +326,9 @@ page_content %}
 </div>
 
 <script>
-  $(document).ready(function () {
-    console.log("executing ready function");
-    if (window.location.hash) {
-      var jQuerytarget = jQuery("body").find(window.location.hash);
-      if (jQuerytarget.hasClass("collapse")) {
-        var jQuerytargetAccordion = jQuerytarget.find(".collapse");
-        jQuerytarget.collapse("show");
-      }
-    }
-  });
+!function(candidate){
+    candidate && new bootstrap.Collapse(candidate, {show:true});
+}(document.querySelector(window.location.hash + ".collapse"));
 </script>
+
 {% endblock %} {% block scripts %} {{ super() }} {% endblock %}


### PR DESCRIPTION
~This removes fetching the jQuery library
as well as the only place when it was used,
which did not work anyways: expanding the
FAQ entry when the page was called with a hash.~

This removes the use of jQuery by
replacing the only place where it
was used with vanilla JS, and it
omits fetching the library altogether.