### PR TITLE
Add GitHub link to footer

### DIFF
--- a/web/static/styles/style.css
+++ b/web/static/styles/style.css
@@ -96,17 +96,3 @@ a.article:hover {
     background: #6d7fcc !important;
     color: #222 !important;
 }
-
-/* ---------------------------------------------------
-    CONTENT STYLE
------------------------------------------------------ */
-
-#content {
-    width: 100%;
-    padding: 20px;
-    min-height: 100vh;
-    transition: all 0.3s;
-    position: absolute;
-    top: 0;
-    right: 0;
-}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -34,16 +34,16 @@
 </head>
 
 <body>
-    <div class="wrapper mt-5">
+    <div class="wrapper">
         <!-- Page Content  -->
         <div id="content">
             {% include 'include/topnav.html' %}
             <div class="container">
                 <div class="row justify-content-center mt-2 mb-5">
-                    <div class="col-auto" "mr-2">
-                        <img src="/static/images/adsb.im.logo.png" width="128" height="128" />
+                    <div class="col-auto">
+                        <img src="/static/images/adsb.im.logo.png" width="128" height="128" alt="ADSB.im logo" />
                     </div>
-                    <div class="col-auto" "ml-2">
+                    <div class="col-auto">
                         <h1 class="red">ADSB.im</h1>
                         <h5>Simple to use <span class="red">ADSB</span> Feeder <span class="red">Im</span>ages<br />(not
                             just) for common Single Board Computers</h5>
@@ -52,6 +52,13 @@
             </div>
             {% block page_content %}
             {% endblock %}
+
+            <div class="container">
+                <footer class="row">
+                    <small class="d-block text-end">Found a typo or something to improve?
+                        <a href="https://github.com/dirkhh/adsb-im-web/blob/main/web/templates/{{active_page}}.html" target="_blank">This page on GitHub</a>.</small>
+                </footer>
+            </div>
         </div>
     </div>
     <div class="overlay"></div>


### PR DESCRIPTION
This adds a convenient deeplink to the
page footer that might invite possible
contributors to fix issues with the docs.
Besides, some unnecessary CSS and attributes
were removed that caused issues on mobile
devices.

<img width="500" alt="image" src="https://github.com/dirkhh/adsb-im-web/assets/1125168/f5ae0102-a54f-4ab4-8e8f-7134c87d3a57">
