### PR TITLE
Harmonize SBC names

### DIFF
--- a/web/templates/faq.html
+++ b/web/templates/faq.html
@@ -45,7 +45,7 @@ page_content %}
           <h5 class="accordion-header">
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapsehalfgig"
                     aria-expanded="false" aria-controls="collapsehalfgig">
-              What about boards with 512MB like the Raspberry Pi 3a or Pi Zero 2
+              What about boards with 512MB like the Raspberry Pi 3 Model A+ or Pi Zero 2
               W?
             </button>
           </h5>
@@ -159,7 +159,7 @@ page_content %}
                 If you are using the DietPi based image
                 <code>adsb-feeder-raspberrypi-dietpi-64...</code>
                 (which is highly recommended if you happen to have a Raspberry
-                Pi Zero 2W or a Pi 3a, both with only 512MB of RAM), things are
+                Pi Zero 2 W or a Pi 3 Model A+, both with only 512MB of RAM), things are
                 unfortunatenly a little harder. Do
                 <em>NOT</em>
                 make any configuration settings in Pi Imager and instead write
@@ -297,7 +297,7 @@ page_content %}
               installation of the necessary software directly on the SBC OS.
               Given that I have tried to be careful in how I set things up, the
               difference isn't very big, but it's there, and especially on a low
-              memory device (e.g., a 512MB RPi Zero2W or RPi 3a) that difference
+              memory device (e.g., a 512MB RPi Zero 2 W or RPi 3 A+) that difference
               can be significant. On the flip side, the moment you consider
               submitting your data to more than one aggregator, the equation
               changes. This is where having a setup like this one really helps

--- a/web/templates/hosting.html
+++ b/web/templates/hosting.html
@@ -38,7 +38,7 @@
     </div>
     <h4 class="mt-2">What hardware is involved?</h4>
     <div class="col-md-12">Typically you would use a single board computer (SBC) like a Raspberry Pi 3/4/5 or an
-      OrangePi Zero3 or simlar.
+      Orange Pi Zero 3 or simlar.
       You connect a Software Defined Radio (SDR) USB dongle to that board and an antenna to that SDR. Ideally this would
       be in a weather proof box outdoors, with the antenna mounted as high as possible with a clear view of the sky -
       but

--- a/web/templates/howto.html
+++ b/web/templates/howto.html
@@ -22,10 +22,10 @@
         <ul>
             <li>A small single board computer (“SBC”): see the list of <a href="supported">currently supported
                     boards</a>; if price is a concern, the OrangePi Zero 3 is a good choice, otherwise one of the
-                Raspberry Pi4 boards is likely the best option.</li>
-            <li>A good power supply for your SBC. Most of the recommended boards use use USB-C (Raspberry Pi4, OrangePi
+                Raspberry Pi 4 boards is likely the best option.</li>
+            <li>A good power supply for your SBC. Most of the recommended boards use use USB-C (Raspberry Pi 4, Orange Pi
                 boards), some others use micro-USB (older Raspberry Pi models, Libre Computer Le Potato, etc) - either
-                way, make sure you use an actual power supply designed for at least 2.5A (or 4A for a Pi4) and not just
+                way, make sure you use an actual power supply designed for at least 2.5A (or 4A for a Pi 4) and not just
                 a USB charger. Bad power is one of the main reasons for random issues with the boards.</li>
             <li>A (good quality) µSD card of at least 8GB with 32GB or more recommended. The SBC will write to it often,
                 so high quality is important. SanDisk Ultra or Samsung High Endurance appear to be good choices.</li>

--- a/web/templates/stage2.html
+++ b/web/templates/stage2.html
@@ -61,7 +61,7 @@
   <div class="mb-3">
     The recommended approach would be to create a new adsb.im Feeder Image installation from scratch; converting an
     existing feeder image could cause unintended effects. Most of the testing is done running a Stage 2 Instance in a
-    VM, additionally some testing is done with a Raspberry Pi 5 and an OrangePi 5plus using NVMe storage. The rest of
+    VM, additionally some testing is done with a Raspberry Pi 5 and an Orange Pi 5 Plus using NVMe storage. The rest of
     this chapter assumes that you already have an Integrated Feeder running and are interested in converting this to a
     two stage system.
   </div>

--- a/web/templates/supported.html
+++ b/web/templates/supported.html
@@ -18,12 +18,12 @@
                 powersupply. For anything more powerful I recommend a 5V/4A power supply.<br />
                 Boards that are actively tested and should work:
                 <ul>
-                    <li>Raspberry Pi4 or Pi5 (the Pi5 certainly is overkill, a Pi4 with 2G RAM will do just fine)</li>
-                    <li>OrangePi Zero 3 (currently my favorite when it comes to price / performance)</li>
-                    <li>Raspberry Pi Zero 2, 3a/b (note that a Raspberry Pi Zero W will NOT work; also, we are
-                        investigating some MLAT instability with Pi3 models, so potentially not the best choice)</li>
-                    <li>Libre Computing Le Potato</li>
-                    <li>Orange Pi 3LTS (no wifi support), 4LTS, 5, and 5plus (these are all known to work, but not
+                    <li>Raspberry Pi 4 or Pi 5 (the Pi 5 certainly is overkill, a Pi&nbsp;4 with 2G RAM will do just fine)</li>
+                    <li>Orange Pi Zero3 (currently my favorite when it comes to price / performance)</li>
+                    <li>Raspberry Pi Zero 2 W, Pi Model 3 A+/B(+) (note that a Raspberry Pi Zero W will NOT work; also, we are
+                        investigating some MLAT instability with Pi 3 models, so potentially not the best choice)</li>
+                    <li>Libre Computer Le Potato</li>
+                    <li>Orange Pi 3 LTS (no wifi support), 4 LTS, 5, and 5 Plus (these are all known to work, but not
                         tested regularly)</li>
                 </ul>
                 Additionally, the software stack can be installed on any board that supports DietPi, and even on most
@@ -38,7 +38,7 @@
                     <li>RadarBox green stick (includes 1090MHz filter and a low noise amplifier)</li>
                     <li>AdsbExchange blue stick (includes 1090MHz filter and a low noise amplifier)</li>
                     <li>RadarBox red stick (includes 978MHz filter and a low noise amplifier -- for UAT978)</li>
-                    <li>Nooelec NESDR Smart</li>
+                    <li>Nooelec NESDR SMArt and SMArTee</li>
                     <li>Most other RTL2838 based USB sticks should work</li>
                     <li>SDRplay RSP1a and RSP1b - other models might work as well</li>
                 </ul>


### PR DESCRIPTION
This harmonizes the names of the SBCs across
the document, e.g. inserts white spaces where
appropriate (Orange Pi, Raspberry Pi Zero 2 W).
The correct writing has carefully been collected
from the manufacturer's web pages.